### PR TITLE
Tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@ pub mod cfg;
 pub mod lr0;
 
 
-//#[cfg(test)]
-//mod tests {
-    //#[test]
-    //fn it_works() {
-    //}
-//}
+// TODO
+//
+// - use traits to make the code more consice
+// - cleanup

--- a/src/lr0.rs
+++ b/src/lr0.rs
@@ -408,7 +408,9 @@ impl LR0 {
                     derivations.push( (nt.clone(), derivation) );
                 },
                 Action::Accept => {
-                    println!("Accepted {:?}", chain);
+                    let w: Vec<String> = chain.iter().map(|t| t.into()).collect();
+                    let w: String = w.join("");
+                    println!("Accepted {:?}", w);
                     for (nt, derivation) in derivations {
                         println!("Reducing by {:?} -> {:?}", nt, derivation);
                     }
@@ -416,11 +418,13 @@ impl LR0 {
                     return true;
                 },
                 Action::Error => {
-                    println!("Parse Error {:?}, {:?}", self.stack, chain);
+                    let w: Vec<String> = chain.iter().map(|t| t.into()).collect();
+                    let w: String = w.join("");
+                    println!("Parse Error {:?}, {:?}", self.stack, w);
 
                     let state = self.stack.pop().unwrap();
                     let token_type: Symbol = token.into();
-                    println!("expected {:?} found {:?} in {:?}", self.expected_symbols(&state), token_type, chain);
+                    println!("expected {:?} found {:?} in {:?}", self.expected_symbols(&state), token_type, w);
                     // In here we can grab the for example ( S and search for right hand side
                     // derivations inside productions that start or contains perhaps that and
                     // basing on that we can do something like "expected ) found nothing"

--- a/tests/parser_expressions.rs
+++ b/tests/parser_expressions.rs
@@ -1,40 +1,40 @@
 #[macro_use] extern crate parsers;
 
 use parsers::cfg::CFG;
-use parsers::lr0::LR0;
+use parsers::lr0::{LR0, Token};
 
 #[test]
 fn expressions_grammar() {
-    let vn = set!('E', 'T', 'F');
-    let vt = set!('+', '*', '(', ')', 'i');
-    let s = 'E';
+    let vn = set!("E", "T", "F");
+    let vt = set!("+", "*", "(", ")", "i");
+    let s = "E";
     let p = vec![
-        ('E', vec!['E', '+', 'T']),
-        ('E', vec!['T']),
-        ('T', vec!['T', '*', 'F']),
-        ('T', vec!['F']),
-        ('F', vec!['(', 'E', ')']),
-        ('F', vec!['i']),
+        ("E", vec!["E", "+", "T"]),
+        ("E", vec!["T"]),
+        ("T", vec!["T", "*", "F"]),
+        ("T", vec!["F"]),
+        ("F", vec!["(", "E", ")"]),
+        ("F", vec!["i"]),
     ];
 
     let g = CFG::new(vn, vt, p, s);
 
     let mut parser = LR0::new(g);
 
-    assert!(parser.parse("i*i".to_string()));
-    assert!(parser.parse("(i*i)".to_string()));
+    assert!(parser.parse( Token::from_str("i*i")));
+    assert!(parser.parse( Token::from_str("(i*i)")));
 
-    assert!(parser.parse("i+i".to_string()));
-    assert!(parser.parse("(i+i)".to_string()));
+    assert!(parser.parse( Token::from_str("i+i")));
+    assert!(parser.parse( Token::from_str("(i+i)")));
 
-    assert!(parser.parse("i*i+i".to_string()));
-    assert!(parser.parse("(i*i)+i".to_string()));
-    assert!(parser.parse("i*(i+i)".to_string()));
-    assert!(parser.parse("(i*i+i)".to_string()));
+    assert!(parser.parse( Token::from_str("i*i+i")));
+    assert!(parser.parse( Token::from_str("(i*i)+i")));
+    assert!(parser.parse( Token::from_str("i*(i+i)")));
+    assert!(parser.parse( Token::from_str("(i*i+i)")));
 
 
-    assert!(!parser.parse("i*".to_string()));
-    assert!(!parser.parse("iiiii".to_string()));
-    assert!(!parser.parse("i*****".to_string()));
+    assert!(!parser.parse( Token::from_str("i*")));
+    assert!(!parser.parse( Token::from_str("iiiii")));
+    assert!(!parser.parse( Token::from_str("i*****")));
 }
 

--- a/tests/parser_expressions.rs
+++ b/tests/parser_expressions.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate parsers;
 
 use parsers::cfg::CFG;
-use parsers::lr0::{LR0, Token};
+use parsers::lr0::{LR0};
 
 #[test]
 fn expressions_grammar() {
@@ -21,20 +21,20 @@ fn expressions_grammar() {
 
     let mut parser = LR0::new(g);
 
-    assert!(parser.parse( Token::from_str("i*i")));
-    assert!(parser.parse( Token::from_str("(i*i)")));
+    assert!(parser.parse( "i*i" ));
+    assert!(parser.parse( "(i*i)" ));
 
-    assert!(parser.parse( Token::from_str("i+i")));
-    assert!(parser.parse( Token::from_str("(i+i)")));
+    assert!(parser.parse( "i+i" ));
+    assert!(parser.parse( "(i+i)" ));
 
-    assert!(parser.parse( Token::from_str("i*i+i")));
-    assert!(parser.parse( Token::from_str("(i*i)+i")));
-    assert!(parser.parse( Token::from_str("i*(i+i)")));
-    assert!(parser.parse( Token::from_str("(i*i+i)")));
+    assert!(parser.parse( "i*i+i" ));
+    assert!(parser.parse( "(i*i)+i" ));
+    assert!(parser.parse( "i*(i+i)" ));
+    assert!(parser.parse( "(i*i+i)" ));
 
 
-    assert!(!parser.parse( Token::from_str("i*")));
-    assert!(!parser.parse( Token::from_str("iiiii")));
-    assert!(!parser.parse( Token::from_str("i*****")));
+    assert!(!parser.parse( "i*" ));
+    assert!(!parser.parse( "iiiii" ));
+    assert!(!parser.parse( "i*****" ));
 }
 

--- a/tests/parser_expressions.rs
+++ b/tests/parser_expressions.rs
@@ -3,7 +3,9 @@
 use parsers::cfg::CFG;
 use parsers::lr0::{LR0};
 
+// this grammar is slr0 after all :(
 #[test]
+#[should_panic]
 fn expressions_grammar() {
     let vn = set!("E", "T", "F");
     let vt = set!("+", "*", "(", ")", "i");

--- a/tests/shift_reduce_conflict.rs
+++ b/tests/shift_reduce_conflict.rs
@@ -1,0 +1,24 @@
+#[macro_use] extern crate parsers;
+
+use parsers::cfg::CFG;
+use parsers::lr0::{LR0};
+
+#[test]
+#[should_panic]
+fn shift_reduce_conflict() {
+    let vn = set!("S", "E");
+    let vt = set!("1");
+    let s = "S";
+    let p = vec![
+        ("S", vec!["E"]),
+        ("E", vec!["1", "E"]),
+        ("E", vec!["1"]),
+    ];
+
+    let g = CFG::new(vn, vt, p, s);
+
+    let mut parser = LR0::new(g);
+
+    assert!(parser.parse( "1" ));
+}
+


### PR DESCRIPTION
- Parser should accept a Token vec
- It should also accept `&str` (implemented via traits)
- Detect and panic on shift/reduction and reduction/reduction conflicts
- Improve memory usage by reducing `.clone()` calls
- Et al